### PR TITLE
Add missing param to sast-coverity-check

### DIFF
--- a/.tekton/foobar-pull-request.yaml
+++ b/.tekton/foobar-pull-request.yaml
@@ -443,6 +443,8 @@ spec:
         - $(params.build-args[*])
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - coverity-availability-check
       taskRef:


### PR DESCRIPTION
Trying to fix this:
```
'[User error] Validation failed for pipelinerun foobar-on-pull-request-pl8xm
      with error invalid input params for task sast-coverity-check: missing values
      for these params which have no default values: [image-digest]'
```